### PR TITLE
Script to figure out what is the appropriate ref for any given MAJOR.MINOR semver

### DIFF
--- a/.travis.example.yml
+++ b/.travis.example.yml
@@ -7,35 +7,31 @@ php:
 
 env:
   global:
-    - REPO_NAME=example_plugin
-    - PLUGIN_NAME=ExamplePlugin
+    - PLUGIN_NAME=Example
     - REQUIRE=""
 
   matrix:
-    - DB=mysql CAKE_VERSION=master
+    - DB=mysql CAKE_VERSION=2.4
     - DB=mysql CAKE_VERSION=2.5
 
 matrix:
   include:
     - php: 5.4
       env:
-        - DB=mysql CAKE_VERSION=master COVERALLS=1
+        - DB=mysql CAKE_VERSION=2.4 COVERALLS=1
     - php: 5.4
       env:
-        - DB=mysql CAKE_VERSION=master PHPCS=1
+        - DB=mysql CAKE_VERSION=2.4 PHPCS=1
 
 before_script:
-  - cd ..
-  - git clone git://github.com/cakephp/cakephp.git --branch $CAKE_VERSION --depth 1
-  - cd cakephp/app
-  - git clone https://github.com/FriendsOfCake/travis.git
-  - ./travis/before_script.sh
+  - git clone https://github.com/FriendsOfCake/travis.git --depth 1 ../travis
+  - ../travis/before_script.sh
 
 script:
-  - ./travis/script.sh
+  - ../travis/script.sh
 
 after_success:
-  - ./travis/after_success.sh
+  - ../travis/after_success.sh
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ satisfying the requirements.
 - Copy the `.travis.example.yml` file to the root of your project and rename it
 to `.travis.yml`
 - Update in the global env variables in .travis.yml
-  - Change `REPO_NAME` to match the github project name, for example `REPO_NAME=example`
   - Change `PLUGIN_NAME` to the camelcased name for a CakePHP plugin `PLUGIN_NAME=Example`
   - Optional: If your need some additional dependencies specific for testing only,
 you can add them in `REQUIRE`. The dependencies should be space separate and in

--- a/after_success.sh
+++ b/after_success.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Move to APP
+cd ../cakephp/app
+
 if [ "$COVERALLS" = '1' ]; then
     php vendor/bin/coveralls -c .coveralls.yml -v;
 fi

--- a/before_script.sh
+++ b/before_script.sh
@@ -1,18 +1,69 @@
 #!/bin/bash
 
+#
+# Returns the latest reference (either a branch or tag) for any given
+# MAJOR.MINOR semantic versioning.
+#
+latest_ref() {
+	# Get version from master branch
+	MASTER=$(curl --silent https://raw.github.com/cakephp/cakephp/master/lib/Cake/VERSION.txt)
+	MASTER=$(echo "$MASTER" | tail -1 | grep -Ei "^$CAKE_VERSION\.")
+	if [ -n "$MASTER" ]; then
+		echo "master"
+		exit 0
+	fi
+
+	# Check if any branch matches CAKE_VERSION
+	BRANCH=$(curl --silent https://api.github.com/repos/cakephp/cakephp/git/refs/heads)
+	BRANCH=$(echo "$BRANCH" | grep -Ei "\"refs/heads/$CAKE_VERSION\"" | grep -oEi "$CAKE_VERSION" | tail -1)
+	if [ -n "$BRANCH" ]; then
+		echo "$BRANCH"
+		exit 0
+	fi
+
+	# Get the latest tag matching CAKE_VERSION.*
+	TAG=$(curl --silent https://api.github.com/repos/cakephp/cakephp/git/refs/tags)
+	TAG=$(echo "$TAG" | grep -Ei "\"refs/tags/$CAKE_VERSION\." | grep -oEi "$CAKE_VERSION\.[^\"]+" | tail -1)
+	if [ -n "$TAG" ]; then
+		echo "$TAG"
+		exit 0
+	fi
+}
+
 if [ "$DB" = "mysql" ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi
 if [ "$DB" = "pgsql" ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi
 
+REPO_PATH=$(pwd)
+SELF_PATH=$(cd "$(dirname "$0")"; pwd)
+
+# Clone CakePHP repository
+CAKE_REF=$(latest_ref)
+if [ -z "$CAKE_REF" ]; then
+	echo "Found no valid ref to match with version $CAKE_VERSION" >&2
+	exit 1
+fi
+
+git clone git://github.com/cakephp/cakephp.git --branch $CAKE_REF --depth 1 ../cakephp
+
+# Prepare plugin
+cd ../cakephp/app
+
 chmod -R 777 tmp
 
-cp ../../$REPO_NAME/composer.json ./composer.json;
+cp -R $REPO_PATH Plugin/$PLUGIN_NAME
 
-composer install --dev --no-interaction --prefer-source
+mv $SELF_PATH/database.php Config/database.php
 
-for dep in $REQUIRE;
-do
+COMPOSER_FILE="$(pwd)/Plugin/$PLUGIN_NAME/composer.json"
+if [ -f "$COMPOSER_FILE" ]; then
+	cp $COMPOSER_FILE ./composer.json;
+
+	composer install --dev --no-interaction --prefer-source
+fi
+
+for dep in $REQUIRE; do
     composer require --dev --no-interaction --prefer-source $dep;
-done;
+done
 
 if [ "$COVERALLS" = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi
 
@@ -20,10 +71,6 @@ if [ "$PHPCS" = '1' ]; then pear channel-discover pear.cakephp.org; fi
 if [ "$PHPCS" = '1' ]; then pear install --alldeps cakephp/CakePHP_CodeSniffer; fi
 
 phpenv rehash
-
-cp -R ../../$REPO_NAME Plugin/$PLUGIN_NAME
-
-mv ./travis/database.php Config/database.php
 
 set +H
 

--- a/script.sh
+++ b/script.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+# Move to APP
+cd ../cakephp/app
+
 if [ "$PHPCS" != '1' ]; then
     ./Console/cake test $PLUGIN_NAME All$PLUGIN_NAME --stderr --coverage-clover build/logs/clover.xml;
 else
     phpcs -p --ignore='*/Test/*' --extensions=php --standard=CakePHP ./Plugin/$PLUGIN_NAME;
 fi
-


### PR DESCRIPTION
The version is compared against cakephp/cakephp repository in this order:
- Check VERSION.txt file on master branch
- Check if any branch names matches the version
- Check if any tag names matches the version

Example:

```
./latest_ref.sh 1.3 // outputs 1.3 (branch)
./latest_ref.sh 2.0 // outputs 2.0.6 (tag)
./latest_ref.sh 2.4 // outputs master (as it is the latest stable release)
```

That prevents us of having to update the travis file every time the master branch changes, or when a branch is removed.
Instead we can just have `2.0` which will be translated to the right ref, 2.0.6 tag in this case.

More information: https://github.com/cakephp/datasources/pull/56/files#r6502358
