### PR TITLE
Added composer autoloader inclusion to before_script

### DIFF
--- a/before_script.sh
+++ b/before_script.sh
@@ -78,7 +78,7 @@ if [ -f "$COMPOSER_AUTOLOAD" ]; then
     echo "App::import('Vendor', array('file' => 'autoload'));" >> Config/bootstrap.php
 fi
 
-echo "CakePlugin::loadAll(array('bootstrap' => true, 'routes' => true, 'ignoreMissing' => true));" >> Config/bootstrap.php
+echo "CakePlugin::loadAll();" >> Config/bootstrap.php
 
 echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <phpunit>


### PR DESCRIPTION
When preparing a plugin to use FoC/travis for all travis bits. I noticed it didn't included the composer autoloader that is generated and required for external libraries. This small fix adds that.
