### PR TITLE
When running phpcs - don't source dependencies

### DIFF
--- a/after_success.sh
+++ b/after_success.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Move to APP
-cd ../cakephp/app
+if [ -d ../cakephp/app ]; then
+	cd ../cakephp/app
+fi
 
 if [ "$COVERALLS" = '1' ]; then
     php vendor/bin/coveralls -c .coveralls.yml -v;

--- a/before_script.sh
+++ b/before_script.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ "$PHPCS" = '1' ]; then
+	pear channel-discover pear.cakephp.org
+	pear install --alldeps cakephp/CakePHP_CodeSniffer
+	phpenv rehash
+	exit 0
+fi
+
 #
 # Returns the latest reference (either a branch or tag) for any given
 # MAJOR.MINOR semantic versioning.
@@ -65,9 +72,6 @@ for dep in $REQUIRE; do
 done
 
 if [ "$COVERALLS" = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi
-
-if [ "$PHPCS" = '1' ]; then pear channel-discover pear.cakephp.org; fi
-if [ "$PHPCS" = '1' ]; then pear install --alldeps cakephp/CakePHP_CodeSniffer; fi
 
 phpenv rehash
 

--- a/script.sh
+++ b/script.sh
@@ -1,27 +1,28 @@
 #!/bin/bash
 
+if [ "$PHPCS" == 1 ]; then
+    ARGS="-p --extensions=php --standard=CakePHP .";
+    if [ -n "$PHPCS_IGNORE" ]; then
+        ARGS="$ARGS --ignore='$PHPCS_IGNORE'"
+    fi
+    eval "phpcs" $ARGS
+    exit $?
+fi
+
 # Move to APP
-cd ../cakephp/app
+if [ -d ../cakephp/app ]; then
+	cd ../cakephp/app
+fi
 
 TEST_EXIT_CODE=0
-PHPCS_EXIT_CODE=0
 VALIDATE_EXIT_CODE=0
 
 if [ "$COVERALLS" == 1 ]; then
     ./Console/cake test $PLUGIN_NAME All$PLUGIN_NAME --stderr --coverage-clover build/logs/clover.xml
     TEST_EXIT_CODE="$?"
-elif [ -z "$PHPCS" -a -z "$FOC_VALIDATE" ]; then
+elif [ -z "$FOC_VALIDATE" ]; then
     ./Console/cake test $PLUGIN_NAME All$PLUGIN_NAME --stderr
     TEST_EXIT_CODE="$?"
-fi
-
-if [ "$PHPCS" == 1 ]; then
-    ARGS="-p --extensions=php --standard=CakePHP ./Plugin/$PLUGIN_NAME";
-    if [ -n "$PHPCS_IGNORE" ]; then
-        ARGS="$ARGS --ignore='$PHPCS_IGNORE'"
-    fi
-    eval "phpcs" $ARGS
-    PHPCS_EXIT_CODE="$?"
 fi
 
 if [ "$FOC_VALIDATE" == 1 ]; then
@@ -38,7 +39,7 @@ if [ "$FOC_VALIDATE" == 1 ]; then
     VALIDATE_EXIT_CODE="$EXIT_CODE"
 fi
 
-EXIT_CODE=$(($TEST_EXIT_CODE + $PHPCS_EXIT_CODE + $VALIDATE_EXIT_CODE))
+EXIT_CODE=$(($TEST_EXIT_CODE + $VALIDATE_EXIT_CODE))
 if [ "$EXIT_CODE" -gt 0 ]; then
     exit 1
 fi

--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -9,7 +9,6 @@ env:
   global:
     - PLUGIN_NAME=Example
     - REQUIRE=""
-    - DB=mysql CAKE_VERSION=2.4
 
   matrix:
     - DB=mysql CAKE_VERSION=2.4


### PR DESCRIPTION
they aren't required, and only make running phpcs slower or (depending
on irrelevant config errors) fail
