### PR TITLE
Make use of --config-set installed_paths

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 if [ "$PHPCS" == 1 ]; then
-    ARGS="-p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=vendor/ .";
+    vendor/bin/phpcs --config-set installed_paths vendor/cakephp/cakephp-codesniffer;
+
+    ARGS="-p --extensions=php --standard=CakePHP --ignore=vendor/ .";
     if [ -n "$PHPCS_IGNORE" ]; then
         ARGS="$ARGS --ignore='$PHPCS_IGNORE'"
     fi


### PR DESCRIPTION
Registers the `cakephp-codesniffer` so it can be used in a way we are used to (`--standard=CakePHP`).
