### PR TITLE
Add self-update

### DIFF
--- a/before_script.sh
+++ b/before_script.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+composer self-update
+
 if [ "$PHPCS" = '1' ]; then
 	composer require 'cakephp/cakephp-codesniffer:*';
 	exit 0


### PR DESCRIPTION
Currently one gets

    Warning: This development build of composer is over 30 days old. 
    It is recommended to update it by running 
    "/home/travis/.phpenv/versions/5.3/bin/composer self-update"
    to get the latest version.

Running this first would resolve this.