### PR TITLE
Lock codesniffer version

### DIFF
--- a/before_script.sh
+++ b/before_script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$PHPCS" = '1' ]; then
-	composer require 'cakephp/cakephp-codesniffer:*';
+	composer require 'cakephp/cakephp-codesniffer:1.*';
 	exit 0
 fi
 


### PR DESCRIPTION
As codesniffer master is now tracking PSR2 this no longer works for TravisCI phpcs