### PR TITLE
Updates .travis.yml for Coveralls Supports

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -20,6 +20,8 @@ matrix:
   include:
     - php: 5.4
       env:
+        - DB=mysql
+        - CAKE_VERSION=2.4
         - COVERALLS=1
     - php: 5.4
       env:


### PR DESCRIPTION
In testing locally, the `before_script` dies because it attempts to load a `CAKE_VERSION` which doesn't exist for the build, adding the `CAKE_VERSION` and `DB` env values to the matrix corrects the issue.

I'm not sure if this is a real issue or if I messed up the implementation of this project.

If it is a real issue, here's a PR that should fix this.

If I messed up the implementation, it would be great to know what the heck I did wrong.

Detailed information regarding the project and where I observed the issue:

For this project: https://github.com/loadsys/CakePHP-SocialLinks/

This PR is where I worked on Coveralls Support: https://github.com/loadsys/CakePHP-SocialLinks/pull/25

### Pre Adding ENV Values

Commit with out working support for Coveralls: https://github.com/loadsys/CakePHP-SocialLinks/commit/a8a31e0ad85d612be973647158b848eafe061e46
Travis Build kicked off for this commit: https://travis-ci.org/loadsys/CakePHP-SocialLinks/builds/56809650
The Coveralls specific Travis build: https://travis-ci.org/loadsys/CakePHP-SocialLinks/jobs/56809669

### Post Adding ENV Values
Commit that enabled support for Coveralls: https://github.com/loadsys/CakePHP-SocialLinks/commit/5af2137f13c582de7c6e9a2018a9cf6ea060e9c3
Travis Build kicked off for this commit: https://travis-ci.org/loadsys/CakePHP-SocialLinks/builds/56812549
The coveralls specific build: https://travis-ci.org/loadsys/CakePHP-SocialLinks/jobs/56812566