### PR TITLE
Exclude Plugin/$PLUGIN_NAME/vendor from phpunit coverage.

### DIFF
--- a/before_script.sh
+++ b/before_script.sh
@@ -93,6 +93,7 @@ echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
         <directory suffix=\".php\">Plugin/$PLUGIN_NAME</directory>
         <exclude>
             <directory suffix=\".php\">Plugin/$PLUGIN_NAME/Test</directory>
+            <directory suffix=\".php\">Plugin/$PLUGIN_NAME/vendor</directory>
         </exclude>
     </whitelist>
 </filter>


### PR DESCRIPTION
If for any reason composer runs in the plugin's directory during a travis build, you will end up with a `vendor/` folder present. PHPUnit will then include this folder in its `clover.xml` coverage output, which can seriously throw off Coveralls code coverage reports.

I can't think of any circumstances where someone might _want_ to include the `vendor/` directory in their code coverage, and its safe to exclude that folder even if it is not present or empty, so to me this change seems pretty safe to make.

Expand [the contents of after_script.sh in this build](https://travis-ci.org/loadsys/CakePHP-Stateless-Auth/jobs/58286758#L241) for an example of the failure described here. Here is the corresponding [Coveralls report](https://coveralls.io/builds/2326241).