### PR TITLE
Prevent time outs because no output was received

### DIFF
--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -27,7 +27,7 @@ matrix:
 
 before_script:
   - git clone -b master https://github.com/FriendsOfCake/travis.git --depth 1 ../travis
-  - ../travis/before_script.sh
+  - travis_wait ../travis/before_script.sh
 
 script:
   - ../travis/script.sh


### PR DESCRIPTION
Lately we see a lot of timed-out builds ([for instance](https://travis-ci.org/Oefenweb/cakephp-edexml/jobs/72882618)):

```
No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.
```

Adding `travis_wait` ([see](http://docs.travis-ci.com/user/build-timeouts/#Build-times-out-because-no-output-was-received)) to the `before_script` should fix the problem.