### PR TITLE
Remove src_dir from .coveralls.yml

### DIFF
--- a/before_script.sh
+++ b/before_script.sh
@@ -102,6 +102,5 @@ echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 </phpunit>" > phpunit.xml
 
 echo "# for php-coveralls
-src_dir: Plugin/$PLUGIN_NAME
 coverage_clover: build/logs/clover.xml
 json_path: build/logs/coveralls-upload.json" > .coveralls.yml


### PR DESCRIPTION
The `src_dir` option is no longer available:
https://github.com/satooshi/php-coveralls/pull/136

Before this PR, php-coveralls throws an exception:
https://travis-ci.org/chinpei215/cakephp-eager-loader/jobs/101469368#L296 (Before)
https://travis-ci.org/chinpei215/cakephp-eager-loader/jobs/101470617#L297 (After)